### PR TITLE
ci: add PR install-checks workflow

### DIFF
--- a/.github/workflows/install-checks.yml
+++ b/.github/workflows/install-checks.yml
@@ -1,0 +1,149 @@
+name: install-checks
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: install-checks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+
+jobs:
+  build-artifacts:
+    name: Build PR artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Set up GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          install-only: true
+
+      - name: Build snapshot archives
+        shell: bash
+        run: >-
+          goreleaser release
+          --snapshot
+          --clean
+          --skip=publish
+
+      - name: Upload Linux amd64 archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: mdtoc-linux-amd64
+          path: dist/mdtoc_linux_amd64.tar.gz
+          if-no-files-found: error
+
+      - name: Upload macOS amd64 archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: mdtoc-darwin-amd64
+          path: dist/mdtoc_darwin_amd64.tar.gz
+          if-no-files-found: error
+
+      - name: Upload Windows amd64 archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: mdtoc-windows-amd64
+          path: dist/mdtoc_windows_amd64.zip
+          if-no-files-found: error
+
+  install-check-linux:
+    name: Install Check Linux
+    runs-on: ubuntu-latest
+    needs: build-artifacts
+    timeout-minutes: 10
+
+    steps:
+      - name: Download Linux amd64 archive
+        uses: actions/download-artifact@v5
+        with:
+          name: mdtoc-linux-amd64
+          path: artifacts
+
+      - name: Unpack archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          tar -xzf artifacts/mdtoc_linux_amd64.tar.gz -C artifacts
+          test -x artifacts/mdtoc_linux_amd64/mdtoc
+
+      - name: Verify binary runs
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifacts/mdtoc_linux_amd64/mdtoc --version
+
+  install-check-macos:
+    name: Install Check macOS
+    runs-on: macos-latest
+    needs: build-artifacts
+    timeout-minutes: 10
+
+    steps:
+      - name: Download macOS amd64 archive
+        uses: actions/download-artifact@v5
+        with:
+          name: mdtoc-darwin-amd64
+          path: artifacts
+
+      - name: Unpack archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          tar -xzf artifacts/mdtoc_darwin_amd64.tar.gz -C artifacts
+          test -x artifacts/mdtoc_darwin_amd64/mdtoc
+
+      - name: Verify binary runs
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifacts/mdtoc_darwin_amd64/mdtoc --version
+
+  install-check-windows:
+    name: Install Check Windows
+    runs-on: windows-latest
+    needs: build-artifacts
+    timeout-minutes: 10
+
+    steps:
+      - name: Download Windows amd64 archive
+        uses: actions/download-artifact@v5
+        with:
+          name: mdtoc-windows-amd64
+          path: artifacts
+
+      - name: Unpack archive
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Expand-Archive -Path artifacts/mdtoc_windows_amd64.zip -DestinationPath artifacts/windows
+          if (-not (Test-Path artifacts/windows/mdtoc_windows_amd64/mdtoc.exe)) {
+            throw 'Expected mdtoc.exe was not found in the Windows archive.'
+          }
+
+      - name: Verify binary runs
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          ./artifacts/windows/mdtoc_windows_amd64/mdtoc.exe --version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@
 * Before every `git push`, explicitly review `CHANGELOG.md`.
 * Before every release tag, release creation, or release publication, explicitly review `CHANGELOG.md`.
 * If the pushed commits affect release notes, unreleased notes, version sections, user-visible behavior, CI, docs, or shipped assets, `CHANGELOG.md` must be updated in the same push.
+* If a task includes committing, pushing, or opening a PR for changes in those areas, treat the `CHANGELOG.md` update as a precondition and do not defer it.
 * Do not push commits first and postpone the `CHANGELOG.md` update for later.
 * A release tag must not be created or published unless the tagged version already exists as its own section in `CHANGELOG.md`.
 * When preparing a release, move the relevant notes from `Unreleased Changes` into the new versioned section and reset `Unreleased Changes` to only cover commits after the new tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file summarizes notable repository changes in a compact, release-oriented f
 
 ### <a id='unreleased-overview'></a>Unreleased Overview
 
+* Pull request install verification was added:
+  * a dedicated `install-checks` GitHub Actions workflow now builds release-style snapshot archives on pull requests
+  * the workflow uploads deterministic Linux, macOS, and Windows artifacts for downstream validation jobs
+  * separate Ubuntu, macOS, and Windows jobs now unpack the PR-built archives and verify that the shipped binary starts successfully
 * README guidance was refined:
   * the feature list now calls out the single-binary, no-external-tools setup
   * usage examples now show safe pipe output to a different file and a simple stdin dry-run pattern


### PR DESCRIPTION
This PR implements issue #11 by adding a dedicated pull-request install-check workflow for release-style artifacts.

The repository previously relied on source-level tests and manual release tooling, but pull requests did not exercise the packaged archives that users would actually download. That left a gap between green unit tests and a broken install path in shipped artifacts.

The fix adds a separate `install-checks` GitHub Actions workflow that runs on `pull_request` and `workflow_dispatch`. A single Linux build job uses GoReleaser in snapshot mode to create deterministic archives for Linux, macOS, and Windows, then uploads them as workflow artifacts. Three downstream jobs fan out across `ubuntu-latest`, `macos-latest`, and `windows-latest`, download the matching archive, unpack it, and verify that the packaged binary starts successfully with `--version`.

The workflow is intentionally small and deterministic. It also adds concurrency cancellation, job timeouts, and explicit archive-content checks so failures are easier to understand and stale runs do not waste CI time. In the same commit, `CHANGELOG.md` was updated for the CI change, and `AGENTS.md` was clarified so changelog updates are treated as a precondition for commit/push/PR tasks in affected areas.

Validation:
- `actionlint .github/workflows/install-checks.yml`
