### PR TITLE
ci: add install smoke-test fixture

### DIFF
--- a/.github/fixtures/install-smoke.md
+++ b/.github/fixtures/install-smoke.md
@@ -1,0 +1,42 @@
+# Install Smoke Fixture
+
+This fixture is used by the install-check workflow.
+
+Expected smoke-test signals after `mdtoc generate`:
+
+* `+` becomes the managed ToC bullet style because live document bullets use `+` most often
+* repeated headings produce distinct anchors such as `#overview` and `#overview-1`
+* headings with leading numbers keep those digits in generated anchors
+* headings inside fenced code blocks stay ignored
+* headings inside `<!-- mdtoc off -->` ... `<!-- mdtoc on -->` stay unmanaged
+
++ dominant plus bullet
++ another dominant plus bullet
++ third dominant plus bullet
++ fourth dominant plus bullet
+
+## 2026 Release Plan
+
+Intro paragraph for the numbered heading case.
+
+### Scope
+
++ nested plus bullet
++ another nested plus bullet
+
+## Overview
+
+```md
+## Code Heading
++ code bullet
+```
+
+<!-- mdtoc off -->
+## Hidden Section
+- excluded dash bullet
+### Hidden Details
+<!-- mdtoc on -->
+
+## Overview
+
+## Final Notes

--- a/.github/workflows/install-checks.yml
+++ b/.github/workflows/install-checks.yml
@@ -75,6 +75,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
       - name: Download Linux amd64 archive
         uses: actions/download-artifact@v5
         with:
@@ -94,6 +97,35 @@ jobs:
           set -euo pipefail
           artifacts/mdtoc_linux_amd64/mdtoc --version
 
+      - name: Run smoke test fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp .github/fixtures/install-smoke.md artifacts/smoke.md
+          artifacts/mdtoc_linux_amd64/mdtoc generate -f artifacts/smoke.md
+          artifacts/mdtoc_linux_amd64/mdtoc check -f artifacts/smoke.md
+          grep -Fq 'bullets=auto' artifacts/smoke.md
+          grep -Fq '+ [1. 2026 Release Plan](#2026-release-plan)' artifacts/smoke.md
+          grep -Fq '+ [2. Overview](#overview)' artifacts/smoke.md
+          grep -Fq '+ [3. Overview](#overview-1)' artifacts/smoke.md
+          grep -Fq '## 1. <a id="2026-release-plan"></a>2026 Release Plan' artifacts/smoke.md
+          grep -Fq '## 2. <a id="overview"></a>Overview' artifacts/smoke.md
+          grep -Fq '## 3. <a id="overview-1"></a>Overview' artifacts/smoke.md
+          grep -Fq '## Hidden Section' artifacts/smoke.md
+          grep -Fq '### Hidden Details' artifacts/smoke.md
+          if grep -Fq 'Code Heading](#code-heading)' artifacts/smoke.md; then
+            echo 'fenced code heading leaked into managed output'
+            exit 1
+          fi
+          if grep -Fq 'Hidden Section](#hidden-section)' artifacts/smoke.md; then
+            echo 'excluded heading leaked into managed ToC'
+            exit 1
+          fi
+          if grep -Fq '## 4. <a id="hidden-section"></a>Hidden Section' artifacts/smoke.md; then
+            echo 'excluded heading was rewritten'
+            exit 1
+          fi
+
   install-check-macos:
     name: Install Check macOS
     runs-on: macos-latest
@@ -101,6 +133,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
       - name: Download macOS amd64 archive
         uses: actions/download-artifact@v5
         with:
@@ -120,6 +155,35 @@ jobs:
           set -euo pipefail
           artifacts/mdtoc_darwin_amd64/mdtoc --version
 
+      - name: Run smoke test fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp .github/fixtures/install-smoke.md artifacts/smoke.md
+          artifacts/mdtoc_darwin_amd64/mdtoc generate -f artifacts/smoke.md
+          artifacts/mdtoc_darwin_amd64/mdtoc check -f artifacts/smoke.md
+          grep -Fq 'bullets=auto' artifacts/smoke.md
+          grep -Fq '+ [1. 2026 Release Plan](#2026-release-plan)' artifacts/smoke.md
+          grep -Fq '+ [2. Overview](#overview)' artifacts/smoke.md
+          grep -Fq '+ [3. Overview](#overview-1)' artifacts/smoke.md
+          grep -Fq '## 1. <a id="2026-release-plan"></a>2026 Release Plan' artifacts/smoke.md
+          grep -Fq '## 2. <a id="overview"></a>Overview' artifacts/smoke.md
+          grep -Fq '## 3. <a id="overview-1"></a>Overview' artifacts/smoke.md
+          grep -Fq '## Hidden Section' artifacts/smoke.md
+          grep -Fq '### Hidden Details' artifacts/smoke.md
+          if grep -Fq 'Code Heading](#code-heading)' artifacts/smoke.md; then
+            echo 'fenced code heading leaked into managed output'
+            exit 1
+          fi
+          if grep -Fq 'Hidden Section](#hidden-section)' artifacts/smoke.md; then
+            echo 'excluded heading leaked into managed ToC'
+            exit 1
+          fi
+          if grep -Fq '## 4. <a id="hidden-section"></a>Hidden Section' artifacts/smoke.md; then
+            echo 'excluded heading was rewritten'
+            exit 1
+          fi
+
   install-check-windows:
     name: Install Check Windows
     runs-on: windows-latest
@@ -127,6 +191,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
       - name: Download Windows amd64 archive
         uses: actions/download-artifact@v5
         with:
@@ -147,3 +214,38 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           ./artifacts/windows/mdtoc_windows_amd64/mdtoc.exe --version
+
+      - name: Run smoke test fixture
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Copy-Item .github/fixtures/install-smoke.md artifacts/smoke.md
+          ./artifacts/windows/mdtoc_windows_amd64/mdtoc.exe generate -f artifacts/smoke.md
+          ./artifacts/windows/mdtoc_windows_amd64/mdtoc.exe check -f artifacts/smoke.md
+          $content = Get-Content artifacts/smoke.md -Raw
+          $required = @(
+            'bullets=auto',
+            '+ [1. 2026 Release Plan](#2026-release-plan)',
+            '+ [2. Overview](#overview)',
+            '+ [3. Overview](#overview-1)',
+            '## 1. <a id="2026-release-plan"></a>2026 Release Plan',
+            '## 2. <a id="overview"></a>Overview',
+            '## 3. <a id="overview-1"></a>Overview',
+            '## Hidden Section',
+            '### Hidden Details'
+          )
+          foreach ($marker in $required) {
+            if (-not $content.Contains($marker)) {
+              throw "Smoke fixture is missing expected marker: $marker"
+            }
+          }
+          $forbidden = @(
+            'Code Heading](#code-heading)',
+            'Hidden Section](#hidden-section)',
+            '## 4. <a id="hidden-section"></a>Hidden Section'
+          )
+          foreach ($marker in $forbidden) {
+            if ($content.Contains($marker)) {
+              throw "Smoke fixture contains forbidden marker: $marker"
+            }
+          }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file summarizes notable repository changes in a compact, release-oriented f
   * the workflow uploads deterministic Linux, macOS, and Windows artifacts for downstream validation jobs
   * separate Ubuntu, macOS, and Windows jobs now unpack the PR-built archives and verify that the shipped binary starts successfully
   * the install jobs now reuse a checked-in smoke-test fixture that exercises repeated headings, numbered headings, exclusions, fenced code, and `+` bullet auto-detection
+  * managed ToC preservation now recognizes generated `*`, `-`, and `+` list entries consistently, and Go tests cover fixture-based `generate` plus `check` file workflows
 * README guidance was refined:
   * the feature list now calls out the single-binary, no-external-tools setup
   * usage examples now show safe pipe output to a different file and a simple stdin dry-run pattern

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file summarizes notable repository changes in a compact, release-oriented f
   * a dedicated `install-checks` GitHub Actions workflow now builds release-style snapshot archives on pull requests
   * the workflow uploads deterministic Linux, macOS, and Windows artifacts for downstream validation jobs
   * separate Ubuntu, macOS, and Windows jobs now unpack the PR-built archives and verify that the shipped binary starts successfully
+  * the install jobs now reuse a checked-in smoke-test fixture that exercises repeated headings, numbered headings, exclusions, fenced code, and `+` bullet auto-detection
 * README guidance was refined:
   * the feature list now calls out the single-binary, no-external-tools setup
   * usage examples now show safe pipe output to a different file and a simple stdin dry-run pattern

--- a/internal/mdtoc/cli_test.go
+++ b/internal/mdtoc/cli_test.go
@@ -292,6 +292,59 @@ func TestRunnerRegenWithFileDoesNotRequireStdin(t *testing.T) {
 	}
 }
 
+// TestRunnerGenerateThenCheckWithFixtureFile verifies the real file workflow used by install checks.
+func TestRunnerGenerateThenCheckWithFixtureFile(t *testing.T) {
+	fixturePath := filepath.Join("..", "..", ".github", "fixtures", "install-smoke.md")
+	input, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error: %v", fixturePath, err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "install-smoke.md")
+	if err := os.WriteFile(path, input, 0o644); err != nil {
+		t.Fatalf("WriteFile error: %v", err)
+	}
+
+	var stdout, stderr strings.Builder
+	runner := newRunner(strings.NewReader(""), &stdout, &stderr, BuildInfo{}, true)
+
+	exitCode, err := runner.Run([]string{"generate", "-f", path})
+	if err != nil {
+		t.Fatalf("generate Run error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("generate exit code = %d, want 0", exitCode)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile error: %v", err)
+	}
+	content := string(got)
+	for _, want := range []string{
+		"bullets=auto",
+		"+ [1. 2026 Release Plan](#2026-release-plan)",
+		"+ [3. Overview](#overview-1)",
+		`## 1. <a id="2026-release-plan"></a>2026 Release Plan`,
+		`## 3. <a id="overview-1"></a>Overview`,
+		"## Hidden Section",
+		"### Hidden Details",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("generated fixture file missing %q:\n%s", want, content)
+		}
+	}
+
+	exitCode, err = runner.Run([]string{"check", "-f", path})
+	if err != nil {
+		t.Fatalf("check Run error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("check exit code = %d, want 0", exitCode)
+	}
+}
+
 // TestRunnerCheckExitCodeOnMismatch verifies the special mismatch exit code from check.
 func TestRunnerCheckExitCodeOnMismatch(t *testing.T) {
 	stdin := strings.NewReader(strings.Join([]string{startMarker, "* [1. Wrong](#wrong)", configStart, "numbering=on", "min-level=2", "max-level=4", "anchors=on", "toc=on", "state=generated", configEnd, endMarker, "", "## Intro"}, "\n") + "\n")

--- a/internal/mdtoc/process.go
+++ b/internal/mdtoc/process.go
@@ -356,7 +356,10 @@ func isGeneratedTOCLine(line string) bool {
 	if trimmed == "" {
 		return true
 	}
-	return strings.HasPrefix(trimmed, "* [") && strings.Contains(trimmed, "](#") && strings.HasSuffix(trimmed, ")")
+	if !(strings.HasPrefix(trimmed, "* [") || strings.HasPrefix(trimmed, "- [") || strings.HasPrefix(trimmed, "+ [")) {
+		return false
+	}
+	return strings.Contains(trimmed, "](#") && strings.HasSuffix(trimmed, ")")
 }
 
 // wrapPreservedComment wraps preserved foreign lines in a generated HTML comment.

--- a/internal/mdtoc/process_test.go
+++ b/internal/mdtoc/process_test.go
@@ -40,6 +40,134 @@ func TestGenerateIsIdempotent(t *testing.T) {
 	}
 }
 
+// TestGenerateIsIdempotentWithPlusBullets verifies repeated generation for auto-detected plus ToCs.
+func TestGenerateIsIdempotentWithPlusBullets(t *testing.T) {
+	input := strings.Join([]string{
+		"# Title",
+		"",
+		"+ alpha",
+		"+ beta",
+		"+ gamma",
+		"",
+		"## Overview",
+		"## Overview",
+	}, "\n") + "\n"
+
+	first, _, err := Generate(input, DefaultOptions())
+	if err != nil {
+		t.Fatalf("first Generate error: %v", err)
+	}
+	if !strings.Contains(first, "+ [1. Overview](#overview)") || !strings.Contains(first, "+ [2. Overview](#overview-1)") {
+		t.Fatalf("first generation did not use plus bullets with repeated headings:\n%s", first)
+	}
+
+	second, _, err := Generate(first, DefaultOptions())
+	if err != nil {
+		t.Fatalf("second Generate error: %v", err)
+	}
+	if first != second {
+		t.Fatalf("generate with plus bullets is not idempotent\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+
+	ok, _, err := Check(first)
+	if err != nil {
+		t.Fatalf("Check error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("Check rejected generated plus-bullet output:\n%s", first)
+	}
+}
+
+// TestGenerateIsIdempotentWithDashBullets verifies repeated generation for auto-detected dash ToCs.
+func TestGenerateIsIdempotentWithDashBullets(t *testing.T) {
+	input := strings.Join([]string{
+		"# Title",
+		"",
+		"- alpha",
+		"- beta",
+		"- gamma",
+		"",
+		"## Overview",
+		"## Overview",
+	}, "\n") + "\n"
+
+	first, _, err := Generate(input, DefaultOptions())
+	if err != nil {
+		t.Fatalf("first Generate error: %v", err)
+	}
+	if !strings.Contains(first, "- [1. Overview](#overview)") || !strings.Contains(first, "- [2. Overview](#overview-1)") {
+		t.Fatalf("first generation did not use dash bullets with repeated headings:\n%s", first)
+	}
+
+	second, _, err := Generate(first, DefaultOptions())
+	if err != nil {
+		t.Fatalf("second Generate error: %v", err)
+	}
+	if first != second {
+		t.Fatalf("generate with dash bullets is not idempotent\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+
+	ok, _, err := Check(first)
+	if err != nil {
+		t.Fatalf("Check error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("Check rejected generated dash-bullet output:\n%s", first)
+	}
+}
+
+// TestGenerateIsIdempotentWithStarBullets verifies repeated generation for explicit star ToCs.
+func TestGenerateIsIdempotentWithStarBullets(t *testing.T) {
+	input := strings.Join([]string{
+		"# Title",
+		"",
+		"- alpha",
+		"- beta",
+		"- gamma",
+		"",
+		"## Overview",
+		"## Overview",
+	}, "\n") + "\n"
+
+	first, _, err := Generate(input, Options{
+		Numbering: true,
+		MinLevel:  2,
+		MaxLevel:  4,
+		Anchors:   true,
+		TOC:       true,
+		Bullets:   BulletStar,
+	})
+	if err != nil {
+		t.Fatalf("first Generate error: %v", err)
+	}
+	if !strings.Contains(first, "* [1. Overview](#overview)") || !strings.Contains(first, "* [2. Overview](#overview-1)") {
+		t.Fatalf("first generation did not use star bullets with repeated headings:\n%s", first)
+	}
+
+	second, _, err := Generate(first, Options{
+		Numbering: true,
+		MinLevel:  2,
+		MaxLevel:  4,
+		Anchors:   true,
+		TOC:       true,
+		Bullets:   BulletStar,
+	})
+	if err != nil {
+		t.Fatalf("second Generate error: %v", err)
+	}
+	if first != second {
+		t.Fatalf("generate with star bullets is not idempotent\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+
+	ok, _, err := Check(first)
+	if err != nil {
+		t.Fatalf("Check error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("Check rejected generated star-bullet output:\n%s", first)
+	}
+}
+
 // TestGeneratePreservesForeignTOCContentAsComment verifies preservation of handwritten managed-area content.
 func TestGeneratePreservesForeignTOCContentAsComment(t *testing.T) {
 	input := strings.Join([]string{startMarker, "Some handwritten note", configStart, "numbering=on", "min-level=2", "max-level=4", "anchors=on", "toc=on", "state=generated", configEnd, endMarker, "", "## Intro"}, "\n") + "\n"


### PR DESCRIPTION
This PR implements issue #12 by adding a shared smoke-test fixture for the install verification workflow.

The install-check workflow already proved that packaged binaries could start, but it still only exercised `mdtoc --version`. That left the artifact validation path too shallow: a release archive could contain a runnable binary while still failing on realistic markdown processing cases.

The fix adds a checked-in fixture at `.github/fixtures/install-smoke.md` and reuses it in the Linux, macOS, and Windows install-check jobs. Each job now downloads the PR-built archive, unpacks it, runs `generate` on the fixture, runs `check` on the generated result, and verifies a focused set of stable output markers. The fixture deliberately covers repeated headings, numbered headings, `mdtoc off/on` exclusion regions, fenced code that must stay ignored, and dominant `+` bullet auto-detection.

This keeps the workflow deterministic while materially increasing confidence that release-style artifacts behave correctly across all three target operating systems. `CHANGELOG.md` was updated in the same push because the change affects CI behavior.

Validation:
- `go test ./...`
- `actionlint .github/workflows/install-checks.yml`
- `go run ./cmd/mdtoc generate -f <temp copy of .github/fixtures/install-smoke.md>`
