### PR TITLE
packaging: add Debian package artifacts

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -88,6 +88,28 @@ archives:
     files:
       - "none*"
 
+nfpms:
+  - id: mdtoc-deb
+    ids:
+      - mdtoc-64bit
+    formats:
+      - deb
+    package_name: mdtoc
+    file_name_template: "{{ .PackageName }}_{{ .Version }}_{{ .Arch }}"
+    vendor: rokath
+    homepage: https://github.com/rokath/mdtoc
+    maintainer: rokath
+    description: >-
+      Go-based Markdown Table of Contents manager with numbering and stable
+      anchor links.
+    license: MIT
+    section: utils
+    priority: optional
+    bindir: /usr/bin
+    contents:
+      - src: LICENSE.md
+        dst: /usr/share/doc/mdtoc/copyright
+
 release:
   footer: |
     ### macOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This file summarizes notable repository changes in a compact, release-oriented f
 * Published release auditing was added:
   * a separate manual `release-audit` workflow now downloads the latest published Linux and Windows release artifacts from GitHub Releases
   * the workflow verifies `mdtoc --version` plus the shared generate/check smoke-test flow against the checked-in install fixture
+* Debian packaging support was added:
+  * GoReleaser now emits `.deb` artifacts for the initial supported Linux package targets
+  * the Debian package metadata is now defined explicitly for `mdtoc`, including package name, homepage, license, install path, and shipped license file
 * README guidance was refined:
   * the feature list now calls out the single-binary, no-external-tools setup
   * usage examples now show safe pipe output to a different file and a simple stdin dry-run pattern


### PR DESCRIPTION
This PR implements issue #15 by adding Debian package artifacts to the GoReleaser configuration via nFPM.

The repository already produced release archives, but there was no real Debian package artifact behind any future Debian installation story. That meant later Debian CI work would have had nothing concrete to install or validate. The goal of this change is to introduce a minimal, intentional `.deb` packaging path before any Debian install tests are added.

The fix extends `.goreleaser.yaml` with an `nfpms` section for Debian packages. The first version is intentionally narrow: it targets the existing Linux `amd64` and `arm64` release builds from `mdtoc-64bit`, emits `.deb` artifacts, installs the binary to `/usr/bin`, and ships the license file under `/usr/share/doc/mdtoc/copyright`. Package metadata such as package name, maintainer, homepage, description, license, section, and priority are defined explicitly so the package is repository-specific rather than implicit.

This keeps the packaging step reviewable and sets up the next logical step: CI installation testing of the produced `.deb` artifacts in issue #16. `CHANGELOG.md` was updated in the same push because this changes shipped release artifacts.

Validation:
- `goreleaser check`
- `go test ./internal/mdtoc ./cmd/mdtoc`
