### PR TITLE
ci: test Debian package installation

### DIFF
--- a/.github/workflows/install-checks.yml
+++ b/.github/workflows/install-checks.yml
@@ -54,6 +54,13 @@ jobs:
           path: dist/mdtoc_linux_amd64.tar.gz
           if-no-files-found: error
 
+      - name: Upload Debian amd64 package
+        uses: actions/upload-artifact@v4
+        with:
+          name: mdtoc-deb-amd64
+          path: dist/mdtoc_*_amd64.deb
+          if-no-files-found: error
+
       - name: Upload macOS amd64 archive
         uses: actions/upload-artifact@v4
         with:
@@ -162,6 +169,61 @@ jobs:
           cp .github/fixtures/install-smoke.md artifacts/smoke.md
           artifacts/mdtoc_darwin_amd64/mdtoc generate -f artifacts/smoke.md
           artifacts/mdtoc_darwin_amd64/mdtoc check -f artifacts/smoke.md
+          grep -Fq 'bullets=auto' artifacts/smoke.md
+          grep -Fq '+ [1. 2026 Release Plan](#2026-release-plan)' artifacts/smoke.md
+          grep -Fq '+ [2. Overview](#overview)' artifacts/smoke.md
+          grep -Fq '+ [3. Overview](#overview-1)' artifacts/smoke.md
+          grep -Fq '## 1. <a id="2026-release-plan"></a>2026 Release Plan' artifacts/smoke.md
+          grep -Fq '## 2. <a id="overview"></a>Overview' artifacts/smoke.md
+          grep -Fq '## 3. <a id="overview-1"></a>Overview' artifacts/smoke.md
+          grep -Fq '## Hidden Section' artifacts/smoke.md
+          grep -Fq '### Hidden Details' artifacts/smoke.md
+          if grep -Fq 'Code Heading](#code-heading)' artifacts/smoke.md; then
+            echo 'fenced code heading leaked into managed output'
+            exit 1
+          fi
+          if grep -Fq 'Hidden Section](#hidden-section)' artifacts/smoke.md; then
+            echo 'excluded heading leaked into managed ToC'
+            exit 1
+          fi
+          if grep -Fq '## 4. <a id="hidden-section"></a>Hidden Section' artifacts/smoke.md; then
+            echo 'excluded heading was rewritten'
+            exit 1
+          fi
+
+  install-check-debian:
+    name: Install Check Debian
+    runs-on: ubuntu-latest
+    needs: build-artifacts
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Download Debian amd64 package
+        uses: actions/download-artifact@v5
+        with:
+          name: mdtoc-deb-amd64
+          path: artifacts
+
+      - name: Install Debian package
+        shell: bash
+        run: |
+          set -euo pipefail
+          package="$(find artifacts -maxdepth 1 -name '*.deb' -print -quit)"
+          test -n "$package"
+          sudo dpkg -i "$package"
+          test -x /usr/bin/mdtoc
+
+      - name: Verify installed binary and smoke test
+        shell: bash
+        run: |
+          set -euo pipefail
+          /usr/bin/mdtoc --version
+          cp .github/fixtures/install-smoke.md artifacts/smoke.md
+          /usr/bin/mdtoc generate -f artifacts/smoke.md
+          /usr/bin/mdtoc check -f artifacts/smoke.md
           grep -Fq 'bullets=auto' artifacts/smoke.md
           grep -Fq '+ [1. 2026 Release Plan](#2026-release-plan)' artifacts/smoke.md
           grep -Fq '+ [2. Overview](#overview)' artifacts/smoke.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This file summarizes notable repository changes in a compact, release-oriented f
 * Debian packaging support was added:
   * GoReleaser now emits `.deb` artifacts for the initial supported Linux package targets
   * the Debian package metadata is now defined explicitly for `mdtoc`, including package name, homepage, license, install path, and shipped license file
+  * pull request install checks now install the generated Debian package on Ubuntu via `dpkg -i` and run the shared smoke-test flow against the installed `/usr/bin/mdtoc`
 * README guidance was refined:
   * the feature list now calls out the single-binary, no-external-tools setup
   * usage examples now show safe pipe output to a different file and a simple stdin dry-run pattern


### PR DESCRIPTION
This PR implements issue #16 by testing the Debian installation path in CI using the generated `.deb` artifact.

Adding Debian package generation in issue #15 was only the first half of the packaging path. A `.deb` artifact is not useful unless CI proves that it can actually be installed and that the installed binary behaves correctly on an Ubuntu/Debian runner. The goal of this change is to validate the install path directly, rather than assuming that a successfully built package is also installable.

The fix extends the existing `install-checks` workflow. The build job now uploads the generated Debian `amd64` package as a workflow artifact, and a new `Install Check Debian` job on `ubuntu-latest` downloads that package, installs it with `dpkg -i`, verifies that `/usr/bin/mdtoc` exists, and then runs the same smoke-test flow used for the archive-based install checks: `mdtoc --version`, `generate -f <fixture>`, and `check -f <fixture>`, plus focused assertions on the generated output.

This keeps the first Debian install test intentionally narrow while proving the path that matters: a Debian package produced from the PR can be installed and used as a normal system binary. `CHANGELOG.md` was updated in the same push because CI behavior changed.

Validation:
- `actionlint .github/workflows/install-checks.yml`
- `go test ./internal/mdtoc ./cmd/mdtoc`
