### PR TITLE
packaging: add RPM package artifacts

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -109,6 +109,24 @@ nfpms:
     contents:
       - src: LICENSE.md
         dst: /usr/share/doc/mdtoc/copyright
+  - id: mdtoc-rpm
+    ids:
+      - mdtoc-64bit
+    formats:
+      - rpm
+    package_name: mdtoc
+    file_name_template: "{{ .PackageName }}_{{ .Version }}_{{ .Arch }}"
+    vendor: rokath
+    homepage: https://github.com/rokath/mdtoc
+    maintainer: rokath
+    description: >-
+      Go-based Markdown Table of Contents manager with numbering and stable
+      anchor links.
+    license: MIT
+    bindir: /usr/bin
+    contents:
+      - src: LICENSE.md
+        dst: /usr/share/licenses/mdtoc/LICENSE.md
 
 release:
   footer: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ This file summarizes notable repository changes in a compact, release-oriented f
   * GoReleaser now emits `.deb` artifacts for the initial supported Linux package targets
   * the Debian package metadata is now defined explicitly for `mdtoc`, including package name, homepage, license, install path, and shipped license file
   * pull request install checks now install the generated Debian package on Ubuntu via `dpkg -i` and run the shared smoke-test flow against the installed `/usr/bin/mdtoc`
+* RPM packaging support was added:
+  * GoReleaser now emits `.rpm` artifacts for the initial supported Linux package targets
+  * the RPM package metadata is now defined explicitly for `mdtoc`, including package name, homepage, license, install path, and shipped license file
 * README guidance was refined:
   * the feature list now calls out the single-binary, no-external-tools setup
   * usage examples now show safe pipe output to a different file and a simple stdin dry-run pattern


### PR DESCRIPTION
This PR implements issue #24 by adding RPM package artifacts to the GoReleaser configuration via nFPM.

The repository already gained Debian package output, but there was still no real RPM artifact behind any future installation path for Fedora-, RHEL-, or SUSE-family systems. That meant RPM support could not be documented or tested in a concrete way. The goal of this change is to introduce a minimal, intentional `.rpm` packaging path before any RPM installation tests are added.

The fix extends `.goreleaser.yaml` with a new `nfpms` entry for RPM packages. The first version mirrors the existing Debian packaging approach: it targets the existing Linux `amd64` and `arm64` release builds from `mdtoc-64bit`, emits `.rpm` artifacts, installs the binary to `/usr/bin`, and ships the license file under `/usr/share/licenses/mdtoc/LICENSE.md`. Package metadata such as package name, maintainer, homepage, description, and license are defined explicitly so the package is repository-specific rather than implicit.

This keeps the packaging change reviewable and sets up the next logical step: CI installation testing of the produced `.rpm` artifacts in issue #25. `CHANGELOG.md` was updated in the same push because this changes shipped release artifacts.

Validation:
- `goreleaser check`
- `go test ./internal/mdtoc ./cmd/mdtoc`
