### PR TITLE
ci: test RPM package installation

### DIFF
--- a/.github/workflows/install-checks.yml
+++ b/.github/workflows/install-checks.yml
@@ -61,6 +61,13 @@ jobs:
           path: dist/mdtoc_*_amd64.deb
           if-no-files-found: error
 
+      - name: Upload RPM amd64 package
+        uses: actions/upload-artifact@v4
+        with:
+          name: mdtoc-rpm-amd64
+          path: dist/mdtoc_*_amd64.rpm
+          if-no-files-found: error
+
       - name: Upload macOS amd64 archive
         uses: actions/upload-artifact@v4
         with:
@@ -214,6 +221,63 @@ jobs:
           package="$(find artifacts -maxdepth 1 -name '*.deb' -print -quit)"
           test -n "$package"
           sudo dpkg -i "$package"
+          test -x /usr/bin/mdtoc
+
+      - name: Verify installed binary and smoke test
+        shell: bash
+        run: |
+          set -euo pipefail
+          /usr/bin/mdtoc --version
+          cp .github/fixtures/install-smoke.md artifacts/smoke.md
+          /usr/bin/mdtoc generate -f artifacts/smoke.md
+          /usr/bin/mdtoc check -f artifacts/smoke.md
+          grep -Fq 'bullets=auto' artifacts/smoke.md
+          grep -Fq '+ [1. 2026 Release Plan](#2026-release-plan)' artifacts/smoke.md
+          grep -Fq '+ [2. Overview](#overview)' artifacts/smoke.md
+          grep -Fq '+ [3. Overview](#overview-1)' artifacts/smoke.md
+          grep -Fq '## 1. <a id="2026-release-plan"></a>2026 Release Plan' artifacts/smoke.md
+          grep -Fq '## 2. <a id="overview"></a>Overview' artifacts/smoke.md
+          grep -Fq '## 3. <a id="overview-1"></a>Overview' artifacts/smoke.md
+          grep -Fq '## Hidden Section' artifacts/smoke.md
+          grep -Fq '### Hidden Details' artifacts/smoke.md
+          if grep -Fq 'Code Heading](#code-heading)' artifacts/smoke.md; then
+            echo 'fenced code heading leaked into managed output'
+            exit 1
+          fi
+          if grep -Fq 'Hidden Section](#hidden-section)' artifacts/smoke.md; then
+            echo 'excluded heading leaked into managed ToC'
+            exit 1
+          fi
+          if grep -Fq '## 4. <a id="hidden-section"></a>Hidden Section' artifacts/smoke.md; then
+            echo 'excluded heading was rewritten'
+            exit 1
+          fi
+
+  install-check-rpm:
+    name: Install Check RPM
+    runs-on: ubuntu-latest
+    needs: build-artifacts
+    timeout-minutes: 10
+    container:
+      image: fedora:42
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Download RPM amd64 package
+        uses: actions/download-artifact@v5
+        with:
+          name: mdtoc-rpm-amd64
+          path: artifacts
+
+      - name: Install RPM package
+        shell: bash
+        run: |
+          set -euo pipefail
+          package="$(find artifacts -maxdepth 1 -name '*.rpm' -print -quit)"
+          test -n "$package"
+          dnf install -y "$package"
           test -x /usr/bin/mdtoc
 
       - name: Verify installed binary and smoke test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This file summarizes notable repository changes in a compact, release-oriented f
 * RPM packaging support was added:
   * GoReleaser now emits `.rpm` artifacts for the initial supported Linux package targets
   * the RPM package metadata is now defined explicitly for `mdtoc`, including package name, homepage, license, install path, and shipped license file
+  * pull request install checks now install the generated RPM package in a Fedora container via `dnf install` and run the shared smoke-test flow against the installed `/usr/bin/mdtoc`
 * README guidance was refined:
   * the feature list now calls out the single-binary, no-external-tools setup
   * usage examples now show safe pipe output to a different file and a simple stdin dry-run pattern


### PR DESCRIPTION
This PR implements issue #25 by testing the RPM installation path in CI using the generated `.rpm` artifact.

Adding RPM package generation in issue #24 was only the first half of the packaging path. An `.rpm` artifact is not useful unless CI proves that it can actually be installed and that the installed binary behaves correctly on an RPM-based environment. The goal of this change is to validate the installation path directly, rather than assuming that a successfully built RPM is also installable.

The fix extends the existing `install-checks` workflow. The build job now uploads the generated RPM `amd64` package as a workflow artifact, and a new `Install Check RPM` job runs on `ubuntu-latest` inside a `fedora:42` container, downloads that package, installs it with `dnf install`, verifies that `/usr/bin/mdtoc` exists, and then runs the same smoke-test flow used for the other install checks: `mdtoc --version`, `generate -f <fixture>`, and `check -f <fixture>`, plus focused assertions on the generated output.

This keeps the first RPM install test intentionally narrow while proving the path that matters: an RPM package produced from the PR can be installed and used as a normal system binary in an RPM-family environment. `CHANGELOG.md` was updated in the same push because CI behavior changed.

Validation:
- `actionlint .github/workflows/install-checks.yml`
- `go test ./internal/mdtoc ./cmd/mdtoc`
