### PR TITLE
packaging: add Alpine APK package artifacts

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -127,6 +127,24 @@ nfpms:
     contents:
       - src: LICENSE.md
         dst: /usr/share/licenses/mdtoc/LICENSE.md
+  - id: mdtoc-apk
+    ids:
+      - mdtoc-64bit
+    formats:
+      - apk
+    package_name: mdtoc
+    file_name_template: "{{ .PackageName }}_{{ .Version }}_{{ .Arch }}"
+    vendor: rokath
+    homepage: https://github.com/rokath/mdtoc
+    maintainer: rokath
+    description: >-
+      Go-based Markdown Table of Contents manager with numbering and stable
+      anchor links.
+    license: MIT
+    bindir: /usr/bin
+    contents:
+      - src: LICENSE.md
+        dst: /usr/share/licenses/mdtoc/LICENSE.md
 
 release:
   footer: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ This file summarizes notable repository changes in a compact, release-oriented f
   * GoReleaser now emits `.rpm` artifacts for the initial supported Linux package targets
   * the RPM package metadata is now defined explicitly for `mdtoc`, including package name, homepage, license, install path, and shipped license file
   * pull request install checks now install the generated RPM package in a Fedora container via `dnf install` and run the shared smoke-test flow against the installed `/usr/bin/mdtoc`
+* Alpine packaging support was added:
+  * GoReleaser now emits `.apk` artifacts for the initial supported Linux package targets
+  * the Alpine package metadata is now defined explicitly for `mdtoc`, including package name, homepage, license, install path, and shipped license file
 * README guidance was refined:
   * the feature list now calls out the single-binary, no-external-tools setup
   * usage examples now show safe pipe output to a different file and a simple stdin dry-run pattern


### PR DESCRIPTION
This PR implements issue #26 by adding Alpine APK package artifacts to the GoReleaser configuration via nFPM.

The repository already gained Debian and RPM package output, but there was still no real Alpine package artifact behind any future installation path for Alpine users or container-based workflows. That meant Alpine support could not be documented or tested in a concrete way. The goal of this change is to introduce a minimal, intentional `.apk` packaging path before any Alpine installation tests are added.

The fix extends `.goreleaser.yaml` with a new `nfpms` entry for Alpine packages. The first version mirrors the existing Debian and RPM packaging approach: it targets the existing Linux `amd64` and `arm64` release builds from `mdtoc-64bit`, emits `.apk` artifacts, installs the binary to `/usr/bin`, and ships the license file under `/usr/share/licenses/mdtoc/LICENSE.md`. Package metadata such as package name, maintainer, homepage, description, and license are defined explicitly so the package is repository-specific rather than implicit.

This keeps the packaging change reviewable and sets up the next logical step: CI installation testing of the produced `.apk` artifacts in issue #27. `CHANGELOG.md` was updated in the same push because this changes shipped release artifacts.

Validation:
- `goreleaser check`
- `go test ./internal/mdtoc ./cmd/mdtoc`
