### PR TITLE
ci: test Alpine APK installation

### DIFF
--- a/.github/workflows/install-checks.yml
+++ b/.github/workflows/install-checks.yml
@@ -68,6 +68,13 @@ jobs:
           path: dist/mdtoc_*_amd64.rpm
           if-no-files-found: error
 
+      - name: Upload APK amd64 package
+        uses: actions/upload-artifact@v4
+        with:
+          name: mdtoc-apk-amd64
+          path: dist/mdtoc_*_amd64.apk
+          if-no-files-found: error
+
       - name: Upload macOS amd64 archive
         uses: actions/upload-artifact@v4
         with:
@@ -284,6 +291,63 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          /usr/bin/mdtoc --version
+          cp .github/fixtures/install-smoke.md artifacts/smoke.md
+          /usr/bin/mdtoc generate -f artifacts/smoke.md
+          /usr/bin/mdtoc check -f artifacts/smoke.md
+          grep -Fq 'bullets=auto' artifacts/smoke.md
+          grep -Fq '+ [1. 2026 Release Plan](#2026-release-plan)' artifacts/smoke.md
+          grep -Fq '+ [2. Overview](#overview)' artifacts/smoke.md
+          grep -Fq '+ [3. Overview](#overview-1)' artifacts/smoke.md
+          grep -Fq '## 1. <a id="2026-release-plan"></a>2026 Release Plan' artifacts/smoke.md
+          grep -Fq '## 2. <a id="overview"></a>Overview' artifacts/smoke.md
+          grep -Fq '## 3. <a id="overview-1"></a>Overview' artifacts/smoke.md
+          grep -Fq '## Hidden Section' artifacts/smoke.md
+          grep -Fq '### Hidden Details' artifacts/smoke.md
+          if grep -Fq 'Code Heading](#code-heading)' artifacts/smoke.md; then
+            echo 'fenced code heading leaked into managed output'
+            exit 1
+          fi
+          if grep -Fq 'Hidden Section](#hidden-section)' artifacts/smoke.md; then
+            echo 'excluded heading leaked into managed ToC'
+            exit 1
+          fi
+          if grep -Fq '## 4. <a id="hidden-section"></a>Hidden Section' artifacts/smoke.md; then
+            echo 'excluded heading was rewritten'
+            exit 1
+          fi
+
+  install-check-apk:
+    name: Install Check Alpine
+    runs-on: ubuntu-latest
+    needs: build-artifacts
+    timeout-minutes: 10
+    container:
+      image: alpine:3.22
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Download APK amd64 package
+        uses: actions/download-artifact@v5
+        with:
+          name: mdtoc-apk-amd64
+          path: artifacts
+
+      - name: Install APK package
+        shell: sh
+        run: |
+          set -eu
+          package="$(find artifacts -maxdepth 1 -name '*.apk' -print -quit)"
+          test -n "$package"
+          apk add --allow-untrusted "$package"
+          test -x /usr/bin/mdtoc
+
+      - name: Verify installed binary and smoke test
+        shell: sh
+        run: |
+          set -eu
           /usr/bin/mdtoc --version
           cp .github/fixtures/install-smoke.md artifacts/smoke.md
           /usr/bin/mdtoc generate -f artifacts/smoke.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This file summarizes notable repository changes in a compact, release-oriented f
 * Alpine packaging support was added:
   * GoReleaser now emits `.apk` artifacts for the initial supported Linux package targets
   * the Alpine package metadata is now defined explicitly for `mdtoc`, including package name, homepage, license, install path, and shipped license file
+  * pull request install checks now install the generated Alpine package in an Alpine container via `apk add --allow-untrusted` and run the shared smoke-test flow against the installed `/usr/bin/mdtoc`
 * README guidance was refined:
   * the feature list now calls out the single-binary, no-external-tools setup
   * usage examples now show safe pipe output to a different file and a simple stdin dry-run pattern


### PR DESCRIPTION
This PR implements issue #27 by testing the Alpine APK installation path in CI using the generated `.apk` artifact.

Adding Alpine package generation in issue #26 was only the first half of the packaging path. An `.apk` artifact is not useful unless CI proves that it can actually be installed and that the installed binary behaves correctly in an Alpine environment. The goal of this change is to validate the installation path directly, rather than assuming that a successfully built APK is also installable.

The fix extends the existing `install-checks` workflow. The build job now uploads the generated APK `amd64` package as a workflow artifact, and a new `Install Check Alpine` job runs on `ubuntu-latest` inside an `alpine:3.22` container, downloads that package, installs it with `apk add --allow-untrusted`, verifies that `/usr/bin/mdtoc` exists, and then runs the same smoke-test flow used for the other install checks: `mdtoc --version`, `generate -f <fixture>`, and `check -f <fixture>`, plus focused assertions on the generated output.

This keeps the first Alpine install test intentionally narrow while proving the path that matters: an APK package produced from the PR can be installed and used as a normal system binary in an Alpine environment. `CHANGELOG.md` was updated in the same push because CI behavior changed.

Validation:
- `actionlint .github/workflows/install-checks.yml`
- `go test ./internal/mdtoc ./cmd/mdtoc`
