### PR TITLE
fix: harden strip --raw fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@
 ## Tests
 
 * Add or update tests when behavior changes.
+* When a behavior change affects CLI file workflows, file mutation, or file-backed command paths, add or update at least one file-level test by default. Prefer the existing virtual filesystem test helpers over OS-level files when feasible.
 * For Go tests in this repository, the standard library `testing` package is the default.
 
 ## Safety

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ This file summarizes notable repository changes in a compact, release-oriented f
 
 ### <a id='unreleased-overview'></a>Unreleased Overview
 
-* None yet.
+* `strip --raw` was hardened:
+  * it now falls back to tolerant container removal when strict config parsing fails for malformed or future managed containers
+  * fallback stripping still removes managed numbering and inline anchors from headings after the container is removed
+  * new regression tests cover future-version config lines, unknown config keys, and malformed config blocks
 
 ### <a id='unreleased-git-log'></a>Unreleased Git Log
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This file summarizes notable repository changes in a compact, release-oriented f
   * it now falls back to tolerant container removal when strict config parsing fails for malformed or future managed containers
   * fallback stripping still removes managed numbering and inline anchors from headings after the container is removed
   * new regression tests cover future-version config lines, unknown config keys, and malformed config blocks
+* Repository testing guidance was tightened:
+  * `AGENTS.md` now requires a file-level test by default for CLI file workflow and file-backed command changes
+  * virtual filesystem test helpers should be preferred over OS-level files when feasible
 
 ### <a id='unreleased-git-log'></a>Unreleased Git Log
 

--- a/internal/mdtoc/cli_workflow_test.go
+++ b/internal/mdtoc/cli_workflow_test.go
@@ -268,3 +268,46 @@ func TestRunnerFileWorkflowRawStripRejectsRegen(t *testing.T) {
 		t.Fatalf("regen after raw strip returned unexpected error: %v", err)
 	}
 }
+
+// TestRunnerFileWorkflowRawStripRecoversMalformedContainer verifies fallback raw stripping through the file-based CLI path.
+func TestRunnerFileWorkflowRawStripRecoversMalformedContainer(t *testing.T) {
+	const path = "doc.md"
+	fs := newMemoryFileSystem(map[string]string{
+		path: strings.Join([]string{
+			startMarker,
+			"* [1. Intro](#intro)",
+			configStart,
+			"container-version=v2",
+			"numbering=on",
+			"min-level=2",
+			"max-level=4",
+			"anchor=github",
+			"toc=on",
+			"bullets=auto",
+			"state=generated",
+			endMarker,
+			"",
+			"## 1. <a id=\"intro\"></a>Intro",
+		}, "\n") + "\n",
+	})
+
+	var stdout, stderr strings.Builder
+	runner := newRunnerWithFS(strings.NewReader(""), &stdout, &stderr, BuildInfo{}, true, fs)
+	exitCode, err := runner.Run([]string{"strip", "--raw", "--verbose", "-f", path})
+	if err != nil {
+		t.Fatalf("Run(strip --raw --verbose -f) error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("Run(strip --raw --verbose -f) exit code = %d, want 0", exitCode)
+	}
+	got := fs.fileString(path)
+	if strings.Contains(got, startMarker) || strings.Contains(got, endMarker) || strings.Contains(got, "<a id=") || strings.Contains(got, "## 1. ") {
+		t.Fatalf("raw strip left malformed-container artifacts behind:\n%s", got)
+	}
+	if !strings.Contains(got, "## Intro") {
+		t.Fatalf("raw strip removed heading text:\n%s", got)
+	}
+	if !strings.Contains(stderr.String(), "fallback parsing") {
+		t.Fatalf("strip --raw did not report fallback parsing:\n%s", stderr.String())
+	}
+}

--- a/internal/mdtoc/process.go
+++ b/internal/mdtoc/process.go
@@ -73,12 +73,83 @@ func Strip(input string) (string, []string, error) {
 // StripRaw removes the entire container, managed numbering, and managed anchors.
 func StripRaw(input string) (string, []string, error) {
 	parsed, err := ParseDocument(input)
-	if err != nil {
+	if err == nil {
+		bodyLines, headings := removeContainerAndNormalizeHeadings(parsed)
+		bodyLines = rewriteHeadings(bodyLines, headings, Config{MinLevel: 1, MaxLevel: 0})
+		return joinLines(bodyLines), parsed.Warnings, nil
+	}
+	bodyLines, warnings, fallbackErr := stripRawFallback(input)
+	if fallbackErr != nil {
 		return "", nil, err
 	}
-	bodyLines, headings := removeContainerAndNormalizeHeadings(parsed)
+	headings, headingWarnings, headingErr := parseHeadings(bodyLines)
+	if headingErr != nil {
+		return "", nil, err
+	}
+	warnings = append(warnings, headingWarnings...)
 	bodyLines = rewriteHeadings(bodyLines, headings, Config{MinLevel: 1, MaxLevel: 0})
-	return joinLines(bodyLines), parsed.Warnings, nil
+	return joinLines(bodyLines), warnings, nil
+}
+
+// stripRawFallback removes the managed container without requiring strict config parsing.
+func stripRawFallback(input string) ([]string, []string, error) {
+	lines := splitLines(strings.ReplaceAll(input, "\r\n", "\n"))
+	startLine, endLine, warnings, err := findManagedContainerBounds(lines)
+	if err != nil {
+		return nil, nil, err
+	}
+	bodyLines := append([]string{}, lines[:startLine]...)
+	bodyLines = append(bodyLines, lines[endLine+1:]...)
+	return bodyLines, warnings, nil
+}
+
+// findManagedContainerBounds locates the outer managed container markers while
+// tolerating malformed config content inside the container.
+func findManagedContainerBounds(lines []string) (int, int, []string, error) {
+	startLine, endLine := -1, -1
+	inFence := false
+	fenceMarker := ""
+	inGenericComment := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if inFence {
+			if isFenceClose(trimmed, fenceMarker) {
+				inFence, fenceMarker = false, ""
+			}
+			continue
+		}
+		if inGenericComment {
+			if strings.Contains(line, "-->") {
+				inGenericComment = false
+			}
+			continue
+		}
+		if marker := fenceOpen(trimmed); marker != "" {
+			inFence, fenceMarker = true, marker
+			continue
+		}
+		switch trimmed {
+		case startMarker:
+			if startLine != -1 {
+				return 0, 0, nil, fmt.Errorf("duplicate %s marker", startMarker)
+			}
+			startLine = i
+			continue
+		case endMarker:
+			if endLine != -1 {
+				return 0, 0, nil, fmt.Errorf("duplicate %s marker", endMarker)
+			}
+			endLine = i
+			continue
+		}
+		if startsGenericHTMLComment(trimmed) && !strings.Contains(trimmed, "-->") {
+			inGenericComment = true
+		}
+	}
+	if startLine == -1 || endLine == -1 || startLine > endLine {
+		return 0, 0, nil, fmt.Errorf("incomplete mdtoc container")
+	}
+	return startLine, endLine, []string{"warning: strip --raw removed a managed container via fallback parsing"}, nil
 }
 
 // Check reconstructs the target state indicated by the stored config and

--- a/internal/mdtoc/process_test.go
+++ b/internal/mdtoc/process_test.go
@@ -513,6 +513,108 @@ func TestStripRawRemovesContainerAndManagedArtifacts(t *testing.T) {
 	}
 }
 
+// TestStripRawRecoversFromFutureContainerVersion verifies raw stripping for a future container format.
+func TestStripRawRecoversFromFutureContainerVersion(t *testing.T) {
+	input := strings.Join([]string{
+		startMarker,
+		"+ [1. Intro](#intro)",
+		configStart,
+		"container-version=v2",
+		"numbering=on",
+		"min-level=2",
+		"max-level=4",
+		"anchors=on",
+		"toc=on",
+		"bullets=auto",
+		"state=generated",
+		configEnd,
+		endMarker,
+		"",
+		"## 1. <a id=\"intro\"></a>Intro",
+	}, "\n") + "\n"
+
+	got, warnings, err := StripRaw(input)
+	if err != nil {
+		t.Fatalf("StripRaw error: %v", err)
+	}
+	if !strings.Contains(strings.Join(warnings, "\n"), "fallback parsing") {
+		t.Fatalf("StripRaw did not report fallback parsing: %v", warnings)
+	}
+	if strings.Contains(got, startMarker) || strings.Contains(got, endMarker) || strings.Contains(got, "<a id=") || strings.Contains(got, "## 1. ") {
+		t.Fatalf("raw strip left future-format managed artifacts behind:\n%s", got)
+	}
+	if !strings.Contains(got, "## Intro") {
+		t.Fatalf("raw strip removed heading text for future container:\n%s", got)
+	}
+}
+
+// TestStripRawRecoversFromUnknownConfigKey verifies raw stripping with a not-yet-known config key.
+func TestStripRawRecoversFromUnknownConfigKey(t *testing.T) {
+	input := strings.Join([]string{
+		startMarker,
+		"* [1. Intro](#intro)",
+		configStart,
+		"numbering=on",
+		"min-level=2",
+		"max-level=4",
+		"anchor=github",
+		"toc=on",
+		"bullets=auto",
+		"state=generated",
+		configEnd,
+		endMarker,
+		"",
+		"## 1. <a id=\"intro\"></a>Intro",
+	}, "\n") + "\n"
+
+	got, warnings, err := StripRaw(input)
+	if err != nil {
+		t.Fatalf("StripRaw error: %v", err)
+	}
+	if !strings.Contains(strings.Join(warnings, "\n"), "fallback parsing") {
+		t.Fatalf("StripRaw did not report fallback parsing: %v", warnings)
+	}
+	if strings.Contains(got, startMarker) || strings.Contains(got, endMarker) || strings.Contains(got, "<a id=") || strings.Contains(got, "## 1. ") {
+		t.Fatalf("raw strip left unknown-key managed artifacts behind:\n%s", got)
+	}
+	if !strings.Contains(got, "## Intro") {
+		t.Fatalf("raw strip removed heading text for unknown-key container:\n%s", got)
+	}
+}
+
+// TestStripRawRecoversFromUnterminatedConfigBlock verifies raw stripping when the config block is malformed.
+func TestStripRawRecoversFromUnterminatedConfigBlock(t *testing.T) {
+	input := strings.Join([]string{
+		startMarker,
+		"* [1. Intro](#intro)",
+		configStart,
+		"numbering=on",
+		"min-level=2",
+		"max-level=4",
+		"anchors=on",
+		"toc=on",
+		"bullets=auto",
+		"state=generated",
+		endMarker,
+		"",
+		"## 1. <a id=\"intro\"></a>Intro",
+	}, "\n") + "\n"
+
+	got, warnings, err := StripRaw(input)
+	if err != nil {
+		t.Fatalf("StripRaw error: %v", err)
+	}
+	if !strings.Contains(strings.Join(warnings, "\n"), "fallback parsing") {
+		t.Fatalf("StripRaw did not report fallback parsing: %v", warnings)
+	}
+	if strings.Contains(got, startMarker) || strings.Contains(got, endMarker) || strings.Contains(got, "<a id=") || strings.Contains(got, "## 1. ") {
+		t.Fatalf("raw strip left malformed-container artifacts behind:\n%s", got)
+	}
+	if !strings.Contains(got, "## Intro") {
+		t.Fatalf("raw strip removed heading text for malformed container:\n%s", got)
+	}
+}
+
 // TestCheckMatchesAndDetectsMismatch verifies both matching and mismatching check outcomes.
 func TestCheckMatchesAndDetectsMismatch(t *testing.T) {
 	generated, _, err := Generate("# Title\n\n## Intro\n", DefaultOptions())


### PR DESCRIPTION
## Summary
- harden  with a tolerant fallback for malformed and future containers
- add function-level and virtual-filesystem CLI tests for the new fallback path
- tighten  so file-backed CLI changes get file-level tests by default

## Verification
- go test ./internal/mdtoc ./cmd/mdtoc
- go test -cover ./internal/mdtoc ./cmd/mdtoc
