### PR TITLE
distribution: add Homebrew tap publishing path

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -62,3 +62,7 @@ jobs:
           # GoReleaser uses it to create or update the GitHub Release and
           # upload the build artifacts (archives, checksums, etc.).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Cross-repository Homebrew tap publishing needs a dedicated token
+          # with contents:write on rokath/homebrew-tap. Configure it as a
+          # repository secret in this repo before running release publishing.
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -88,6 +88,27 @@ archives:
     files:
       - "none*"
 
+brews:
+  - ids:
+      - mdtoc
+    name: mdtoc
+    repository:
+      owner: rokath
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: https://github.com/rokath/mdtoc
+    description: Go-based Markdown Table of Contents manager with numbering and stable anchor links.
+    license: MIT
+    directory: Formula
+    commit_author:
+      name: github-actions[bot]
+      email: 41898282+github-actions[bot]@users.noreply.github.com
+    install: |
+      bin.install "mdtoc"
+    test: |
+      system "#{bin}/mdtoc", "--version"
+
 nfpms:
   - id: mdtoc-deb
     ids:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This file summarizes notable repository changes in a compact, release-oriented f
 * Repository testing guidance was tightened:
   * `AGENTS.md` now requires a file-level test by default for CLI file workflow and file-backed command changes
   * virtual filesystem test helpers should be preferred over OS-level files when feasible
+* Homebrew tap publishing was added:
+  * GoReleaser now publishes a formula for `mdtoc` into `rokath/homebrew-tap`
+  * the release workflow now documents the required `HOMEBREW_TAP_GITHUB_TOKEN` secret for cross-repository publishing
+  * the README now documents the intended install command `brew install rokath/tap/mdtoc`
 
 ### <a id='unreleased-git-log'></a>Unreleased Git Log
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ state=generated
 
 Download a prebuilt binary from [GitHub Releases](https://github.com/rokath/mdtoc/releases).
 
+Homebrew tap install:
+
+```bash
+brew install rokath/tap/mdtoc
+```
+
 ### 2.2. <a id="build-from-source"></a>Build from source
 
 ```bash


### PR DESCRIPTION
## Summary
- add GoReleaser Homebrew formula publishing to rokath/homebrew-tap
- document the required HOMEBREW_TAP_GITHUB_TOKEN secret for cross-repository publishing
- document the intended install command brew install rokath/tap/mdtoc

## Verification
- goreleaser check
- go test ./internal/mdtoc ./cmd/mdtoc
