### PR TITLE
fix(ci): use canonical Homebrew tap command

### DIFF
--- a/.github/workflows/release-audit.yml
+++ b/.github/workflows/release-audit.yml
@@ -81,7 +81,7 @@ jobs:
           tag=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)
           brew uninstall --force mdtoc || true
           brew untap rokath/tap || true
-          brew tap rokath/tap https://github.com/rokath/homebrew-tap
+          brew tap rokath/tap
           brew install rokath/tap/mdtoc
           version_output="$(mdtoc --version)"
           printf '%s\n' "$version_output"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file summarizes notable repository changes in a compact, release-oriented f
 
 ### <a id='unreleased-overview'></a>Unreleased Overview
 
+* Homebrew release auditing was corrected:
+  * the macOS Homebrew audit now uses the canonical tap command `brew tap rokath/tap`
+  * this matches the documented user install path and avoids a false-negative audit failure
 * `strip --raw` was hardened:
   * it now falls back to tolerant container removal when strict config parsing fails for malformed or future managed containers
   * fallback stripping still removes managed numbering and inline anchors from headings after the container is removed


### PR DESCRIPTION
## Summary
- switch the Homebrew release audit to the canonical tap command brew tap rokath/tap
- keep the audit aligned with the documented user install path brew install rokath/tap/mdtoc
- avoid the previous false-negative audit failure on macOS

## Verification
- actionlint .github/workflows/release-audit.yml
