### PR TITLE
fix(ci): simplify Homebrew release audit

### DIFF
--- a/.github/workflows/release-audit.yml
+++ b/.github/workflows/release-audit.yml
@@ -79,8 +79,6 @@ jobs:
         run: |
           set -euo pipefail
           tag=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)
-          brew uninstall --force mdtoc || true
-          brew untap rokath/tap || true
           brew tap rokath/tap
           brew install rokath/tap/mdtoc
           version_output="$(mdtoc --version)"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -171,16 +171,15 @@ release:
   footer: |
     ### macOS
 
-    If Gatekeeper blocks the downloaded tool, remove the quarantine flag from
-    the unpacked binary path, for example:
-
+    Install via Homebrew: `brew install rokath/tap/mdtoc`
+    - OR -
+    Download and execute the appropriate binary. If Gatekeeper blocks the downloaded tool,
+    remove the quarantine flag from the unpacked binary path, for example:
     `xattr -d com.apple.quarantine path/to/mdtoc`
 
     ### Windows
 
     If SmartScreen or the file block flag gets in the way, unblock the unpacked
-    binary path, for example:
-
-    `Unblock-File path\to\mdtoc.exe`
+    binary path, for example: `Unblock-File path\to\mdtoc.exe`
 
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,9 @@
 * If the pushed commits affect release notes, unreleased notes, version sections, user-visible behavior, CI, docs, or shipped assets, `CHANGELOG.md` must be updated in the same push.
 * If a task includes committing, pushing, or opening a PR for changes in those areas, treat the `CHANGELOG.md` update as a precondition and do not defer it.
 * Do not push commits first and postpone the `CHANGELOG.md` update for later.
+* Before editing `CHANGELOG.md` on a working branch, first reconcile it with the current `origin/main` state if any changelog or release-preparation PRs have merged in the meantime.
+* Do not continue a structurally older `CHANGELOG.md` on `dev` after release-preparation work has already been merged into `main`; sync first, then add new unreleased notes.
+* If `CHANGELOG.md` on the current branch differs structurally from `origin/main` around `Unreleased Changes` or recent version sections, fix that divergence before adding or moving entries.
 * A release tag must not be created or published unless the tagged version already exists as its own section in `CHANGELOG.md`.
 * When preparing a release, move the relevant notes from `Unreleased Changes` into the new versioned section and reset `Unreleased Changes` to only cover commits after the new tag.
 * After tagging or before pushing tagged release commits, verify that the latest repository tag mentioned by `git tag` is present in `CHANGELOG.md` with the correct version header and git range.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,55 @@ This file summarizes notable repository changes in a compact, release-oriented f
 
 ### <a id='unreleased-git-log'></a>Unreleased Git Log
 
-Used git range: `v0.1.5..HEAD`
+Used git range: `v0.1.6..HEAD`
 
 ```txt
+```
+
+## <a id='v0.1.6-changes'></a>v0.1.6 Changes (2026-04-23)
+
+### <a id='v0.1.6-overview'></a>v0.1.6 Overview
+
+* Homebrew release auditing was corrected:
+  * the macOS Homebrew audit now uses the canonical tap command `brew tap rokath/tap`
+  * this matches the documented user install path and avoids a false-negative audit failure
+
+### <a id='v0.1.6-git-log'></a>v0.1.6 Git Log
+
+Used git range: `v0.1.5..v0.1.6`
+
+```txt
+* 7760117 2026-04-22 fix(ci): use canonical Homebrew tap command
+```
+
+## <a id='v0.1.5-changes'></a>v0.1.5 Changes (2026-04-22)
+
+### <a id='v0.1.5-overview'></a>v0.1.5 Overview
+
+* `strip --raw` was hardened:
+  * it now falls back to tolerant container removal when strict config parsing fails for malformed or future managed containers
+  * fallback stripping still removes managed numbering and inline anchors from headings after the container is removed
+  * new regression tests cover future-version config lines, unknown config keys, malformed config blocks, and a file-level CLI fallback path
+* Repository testing guidance was tightened:
+  * `AGENTS.md` now requires a file-level test by default for CLI file workflow and file-backed command changes
+  * virtual filesystem test helpers should be preferred over OS-level files when feasible
+* Homebrew distribution support was added:
+  * GoReleaser now publishes a formula for `mdtoc` into `rokath/homebrew-tap`
+  * the release workflow now documents the required `HOMEBREW_TAP_GITHUB_TOKEN` secret for cross-repository publishing
+  * the README now documents the intended install command `brew install rokath/tap/mdtoc`
+* Homebrew release auditing was added:
+  * the manual `release-audit` workflow now runs a macOS Homebrew install audit against `brew install rokath/tap/mdtoc`
+  * the audit verifies that the installed Homebrew binary matches the latest GitHub release tag and passes the shared smoke-test fixture
+
+### <a id='v0.1.5-git-log'></a>v0.1.5 Git Log
+
+Used git range: `v0.1.4..v0.1.5`
+
+```txt
+* e15ccd6 2026-04-22 ci: audit Homebrew installation path
+* dc13519 2026-04-22 distribution: add Homebrew tap publishing path
+* 8ca3e1e 2026-04-22 docs(agents): require file-level workflow tests by default
+* cb57d2b 2026-04-22 fix(strip): harden raw strip fallback
 ```
 
 ## <a id='v0.1.4-changes'></a>v0.1.4 Changes (2026-04-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ This file summarizes notable repository changes in a compact, release-oriented f
 ### <a id='unreleased-overview'></a>Unreleased Overview
 
 * Homebrew release auditing was corrected:
-  * the macOS Homebrew audit now uses the canonical tap command `brew tap rokath/tap`
-  * this matches the documented user install path and avoids a false-negative audit failure
+  * the macOS Homebrew audit now uses the minimal user-facing path with `brew tap rokath/tap`
+  * unnecessary cleanup steps were removed so the CI path stays aligned with `brew install rokath/tap/mdtoc`
+* Release notes were refined:
+  * the GoReleaser release footer now includes the Homebrew install command `brew install rokath/tap/mdtoc`
 
 ### <a id='unreleased-git-log'></a>Unreleased Git Log
 


### PR DESCRIPTION
## Summary
- remove unnecessary Homebrew cleanup steps from the macOS release-audit job
- keep the audit aligned with the user-facing path brew tap rokath/tap and brew install rokath/tap/mdtoc
- add the Homebrew install command to the GoReleaser release footer

## Verification
- actionlint .github/workflows/release-audit.yml
- goreleaser check
