### PR TITLE
fix(ci): normalize Homebrew audit version check

### DIFF
--- a/.github/workflows/release-audit.yml
+++ b/.github/workflows/release-audit.yml
@@ -79,12 +79,13 @@ jobs:
         run: |
           set -euo pipefail
           tag=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)
+          expected_version="${tag#v}"
           brew tap rokath/tap
           brew install rokath/tap/mdtoc
           version_output="$(mdtoc --version)"
           printf '%s\n' "$version_output"
           case "$version_output" in
-            *"mdtoc $tag"*) ;;
+            *"mdtoc $expected_version"*) ;;
             *)
               echo "installed Homebrew version does not match latest release tag $tag"
               exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file summarizes notable repository changes in a compact, release-oriented f
 
 ### <a id='unreleased-overview'></a>Unreleased Overview
 
+* Homebrew release auditing was corrected:
+  * the version assertion now normalizes the release tag from `vX.Y.Z` to `X.Y.Z` before comparing it with `mdtoc --version`
+
 ### <a id='unreleased-git-log'></a>Unreleased Git Log
 
 Used git range: `v0.1.7..HEAD`


### PR DESCRIPTION
Summary
- normalize the release tag from vX.Y.Z to X.Y.Z before comparing it with mdtoc --version in the Homebrew release audit
- record the post-v0.1.7 audit fix in CHANGELOG.md

Verification
- actionlint .github/workflows/release-audit.yml
