### PR TITLE
release: prepare v0.2.4

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mdtoc-vscode",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mdtoc-vscode",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.15.17",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "mdtoc",
   "displayName": "mdtoc - Markdown ToC with Renumbering-Safe Links",
   "description": "Generate and strip stable Markdown tables of contents from VS Code.",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "publisher": "rokath",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- prepare the v0.2.4 release commit on dev
- align the extension version files for the release
- keep changelog-based release preparation on the non-protected branch flow

## Testing
- not run (release preparation only)